### PR TITLE
Add AWS cognito pool regex

### DIFF
--- a/scanner/secrets.go
+++ b/scanner/secrets.go
@@ -328,6 +328,13 @@ func GetSecretRegexes() []Secret {
 			"?",
 		},
 		{
+			"AWS cognito pool",
+			"AWS Cognito pool",
+			`(us-east-1:[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}|us-east-2:[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}|us-west-1:[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12|us-west-2:[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}|sa-east-1:[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}|sa-east-1:[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}}|sa-east-1:[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12})`,
+			[]string{},
+			"?",
+		},
+		{
 			"S3 Bucket",
 			"S3 Bucket",
 			`(?:[a-zA-Z0-9_-]+s3\.amazonaws\.com|[a-zA-Z0-9_.-]+amazonaws\.com|` +


### PR DESCRIPTION
Using Cognito for authentication is quite popular nowadays, especially in mobile apps.
Developers often hardcode Cognito Identity Pool which allows an unauthenticated attacker to possibly abuse the AWS services associated with that pool identity.