### PR TITLE
Add -insecure flag to ignore invalid HTTPS certificates

### DIFF
--- a/input/flags.go
+++ b/input/flags.go
@@ -48,6 +48,7 @@ type Input struct {
 	Intensive     bool
 	Rua           bool
 	Proxy         string
+	Insecure      bool
 	Secrets       bool
 	SecretsFile   string
 	Endpoints     bool
@@ -81,6 +82,7 @@ func ScanFlag() Input {
 	intensivePtr := flag.Bool("intensive", false, "Crawl searching for resources matching 2nd level domain.")
 	ruaPtr := flag.Bool("rua", false, "Use a random browser user agent on every request.")
 	proxyPtr := flag.String("proxy", "", "Set a Proxy to be used (http and socks5 supported).")
+	insecurePtr := flag.Bool("insecure", false, "Ignore invalid HTTPS certificates")
 
 	secretsPtr := flag.Bool("s", false, "Hunt for secrets.")
 	secretsFilePtr := flag.String("sf", "", "Use an external file (txt, one per line) to use custom regexes for secrets hunting.")
@@ -119,6 +121,7 @@ func ScanFlag() Input {
 		*intensivePtr,
 		*ruaPtr,
 		*proxyPtr,
+		*insecurePtr,
 		*secretsPtr,
 		*secretsFilePtr,
 		*endpointsPtr,

--- a/main.go
+++ b/main.go
@@ -121,7 +121,7 @@ func main() {
 
 		results, secrets, endpoints, extensions, errors, infos := crawler.Crawler(inp, ResultTxt, ResultHtml, flags.Delay,
 			flags.Concurrency, flags.Ignore, flags.IgnoreTxt, flags.Cache, flags.Timeout, flags.Intensive,
-			flags.Rua, flags.Proxy, flags.Secrets, secretsFileSlice, flags.Plain, flags.Endpoints, endpointsFileSlice,
+			flags.Rua, flags.Proxy, flags.Insecure, flags.Secrets, secretsFileSlice, flags.Plain, flags.Endpoints, endpointsFileSlice,
 			flags.Extensions, headers, flags.Errors, flags.Info, flags.Debug, flags.UserAgent)
 
 		finalResults = append(finalResults, results...)


### PR DESCRIPTION
In case the HTTPS certificate is not valid, cariddi just exit.
I added a new `-insecure` boolean flag (defaults to `false`) to ignore invalid HTTPS certificates.