### PR TITLE
Print only the currently visited URL rather than the URL it scraped

### DIFF
--- a/pkg/crawler/colly.go
+++ b/pkg/crawler/colly.go
@@ -221,9 +221,7 @@ func New(target string, txt string, html string, delayTime int, concurrency int,
 			// HERE SCAN FOR SECRETS
 			if secretsFlag && lengthOk {
 				secretsSlice := huntSecrets(secretsFile, r.Request.URL.String(), string(r.Body))
-				for _, elem := range secretsSlice {
-					FinalSecrets = append(FinalSecrets, elem)
-				}
+				FinalSecrets = append(FinalSecrets, secretsSlice...)
 			}
 			// HERE SCAN FOR ENDPOINTS
 			if endpointsFlag {

--- a/pkg/crawler/colly.go
+++ b/pkg/crawler/colly.go
@@ -242,17 +242,13 @@ func New(target string, txt string, html string, delayTime int, concurrency int,
 			// HERE SCAN FOR ERRORS
 			if errorsFlag {
 				errorsSlice := huntErrors(r.Request.URL.String(), string(r.Body))
-				for _, elem := range errorsSlice {
-					FinalErrors = append(FinalErrors, elem)
-				}
+				FinalErrors = append(FinalErrors, errorsSlice...)
 			}
 
 			// HERE SCAN FOR INFOS
 			if infoFlag {
 				infosSlice := huntInfos(r.Request.URL.String(), string(r.Body))
-				for _, elem := range infosSlice {
-					FinalInfos = append(FinalInfos, elem)
-				}
+				FinalInfos = append(FinalInfos, infosSlice...)
 			}
 		}
 	})

--- a/pkg/crawler/colly.go
+++ b/pkg/crawler/colly.go
@@ -112,6 +112,11 @@ func New(target string, txt string, html string, delayTime int, concurrency int,
 	// crawler creation
 	c := CreateColly(delayTime, concurrency, cache, timeout, intensive, rua, proxy, insecure, userAgent, target)
 
+	// On every request that Colly is making, print the URL it's currently visiting
+	c.OnRequest(func(e *colly.Request) {
+		fmt.Println(e.URL.String())
+	})
+
 	// On every a element which has href attribute call callback
 	c.OnHTML("a[href]", func(e *colly.HTMLElement) {
 		link := e.Attr("href")
@@ -210,8 +215,6 @@ func New(target string, txt string, html string, delayTime int, concurrency int,
 	}
 
 	c.OnResponse(func(r *colly.Response) {
-		fmt.Println(r.Request.URL.String())
-
 		minBodyLentgh := 10
 
 		lengthOk := len(string(r.Body)) > minBodyLentgh


### PR DESCRIPTION
Hey there, this fix should solve issue #79 !
To solve it I'm using [(*Collector).OnRequest](https://pkg.go.dev/github.com/gocolly/colly#Collector.OnRequest) method to print the URL that is actively being visited. [Colly's doc](https://pkg.go.dev/github.com/gocolly/colly#section-readme:~:text=Extensions-,Example,-func%20main()%20%7B%0A%09c) also shows this method being used for this specific use case so I'd be tempted to say this is the best way of doing this.
![image](https://user-images.githubusercontent.com/92945113/201782333-b7739d50-1aa1-44c0-8e61-5e81e5c83efd.png)

I've also slipped in some simplifications of some for .. range loops that were proposed by go-staticcheck

Let me know what you think of it!