### PR TITLE
feat: add Go releases using `goreleaser`

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+  categories:
+    - title: 🎉 New Features
+      labels:
+        - "Type: Enhancement"
+    - title: 🐞 Bug Fixes
+      labels:
+        - "Type: Bug" 
+    - title: 🔨 Maintenance
+      labels:
+        - "Type: Maintenance" 
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -1,0 +1,30 @@
+name: 🎉 Release Binary
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest-16-cores
+    steps:
+      - name: "Check out code"
+        uses: actions/checkout@v3
+        with: 
+          fetch-depth: 0
+
+      - name: "Set up Go"
+        uses: actions/setup-go@v4
+        with: 
+          go-version: 1.21.x
+
+      - name: "Create release on GitHub"
+        uses: goreleaser/goreleaser-action@v4
+        with: 
+          args: "release --clean"
+          version: latest
+          workdir: .
+        env: 
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,0 +1,28 @@
+name: 🔨 Release Test
+
+on:
+  pull_request:
+    paths:
+      - '**.go'
+      - '**.mod'
+  workflow_dispatch:
+
+jobs:
+  release-test:
+    runs-on: ubuntu-latest-16-cores
+    steps:
+      - name: "Check out code"
+        uses: actions/checkout@v3
+        with: 
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+      
+      - name: release test
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          args: "release --clean --snapshot"
+          version: latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,33 @@
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - 386
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: '386'
+      - goos: windows
+        goarch: 'arm'
+      - goos: windows
+        goarch: 'arm64'
+    binary: '{{ .ProjectName }}'
+    main: ./cmd/cariddi/
+
+archives:
+- format: zip
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}'
+
+checksum:
+  algorithm: sha256
+


### PR DESCRIPTION
- Adds support for binary releases (pre-compiled packages) with `goreleaser`
- Add `release-test.yml` and `release-binary.yml` GitHub workflows
- Add `release.yml`

This fixes https://github.com/edoardottt/cariddi/issues/146