### PR TITLE
Feat/save responses to output directory provided in new -srd flag and also print if in json if -json flag enabled fixes #128, #129, #130

### DIFF
--- a/cmd/cariddi/main.go
+++ b/cmd/cariddi/main.go
@@ -69,26 +69,31 @@ func main() {
 	// Setup the config according to the flags that were
 	// passed via the CLI
 	config := &crawler.Scan{
-		Delay:          flags.Delay,
-		Concurrency:    flags.Concurrency,
-		Ignore:         flags.Ignore,
-		IgnoreTxt:      flags.IgnoreTXT,
-		Cache:          flags.Cache,
-		JSON:           flags.JSON,
-		Timeout:        flags.Timeout,
-		Intensive:      flags.Intensive,
-		Rua:            flags.Rua,
-		Proxy:          flags.Proxy,
-		SecretsFlag:    flags.Secrets,
-		Plain:          flags.Plain,
-		EndpointsFlag:  flags.Endpoints,
-		FileType:       flags.Extensions,
-		ErrorsFlag:     flags.Errors,
-		InfoFlag:       flags.Info,
-		Debug:          flags.Debug,
-		UserAgent:      flags.UserAgent,
-		StoreResp:      flags.StoreResp,
-		StoredRespPath: flags.StoredRespDir,
+		Delay:         flags.Delay,
+		Concurrency:   flags.Concurrency,
+		Ignore:        flags.Ignore,
+		IgnoreTxt:     flags.IgnoreTXT,
+		Cache:         flags.Cache,
+		JSON:          flags.JSON,
+		Timeout:       flags.Timeout,
+		Intensive:     flags.Intensive,
+		Rua:           flags.Rua,
+		Proxy:         flags.Proxy,
+		SecretsFlag:   flags.Secrets,
+		Plain:         flags.Plain,
+		EndpointsFlag: flags.Endpoints,
+		FileType:      flags.Extensions,
+		ErrorsFlag:    flags.Errors,
+		InfoFlag:      flags.Info,
+		Debug:         flags.Debug,
+		UserAgent:     flags.UserAgent,
+		StoreResp:     flags.StoreResp,
+	}
+
+	config.OutputDir = output.CariddiOutputFolder
+	if flags.StoredRespDir != "" {
+		config.OutputDir = flags.StoredRespDir
+		config.StoreResp = true
 	}
 
 	// Read the targets from standard input.
@@ -119,18 +124,18 @@ func main() {
 	// Create output files if needed (txt / html).
 	config.Txt = ""
 	if flags.TXTout != "" {
-		config.Txt = fileUtils.CreateOutputFile(flags.TXTout, "results", "txt", config.StoredRespPath)
+		config.Txt = fileUtils.CreateOutputFile(flags.TXTout, "results", "txt", config.OutputDir)
 	}
 
 	var ResultHTML = ""
 	if flags.HTMLout != "" {
-		ResultHTML = fileUtils.CreateOutputFile(flags.HTMLout, "", "html", config.StoredRespPath)
+		ResultHTML = fileUtils.CreateOutputFile(flags.HTMLout, "", "html", config.OutputDir)
 		output.BannerHTML(ResultHTML)
 		output.HeaderHTML("Results", ResultHTML)
 	}
 
 	if config.StoreResp {
-		fileUtils.CreateIndexOutputFile("index.responses.txt", config.StoredRespPath)
+		fileUtils.CreateIndexOutputFile("index.responses.txt", config.OutputDir)
 	}
 
 	// Read headers if needed
@@ -168,13 +173,13 @@ func main() {
 	// IF TXT OUTPUT >
 	if flags.TXTout != "" {
 		output.TxtOutput(flags, finalResults, finalSecret, finalEndpoints,
-			finalExtensions, finalErrors, finalInfos)
+			finalExtensions, finalErrors, finalInfos, config.OutputDir)
 	}
 
 	// IF HTML OUTPUT >
 	if flags.HTMLout != "" {
 		output.HTMLOutput(flags, ResultHTML, finalResults, finalSecret,
-			finalEndpoints, finalExtensions, finalErrors, finalInfos)
+			finalEndpoints, finalExtensions, finalErrors, finalInfos, config.OutputDir)
 	}
 
 	// If needed print secrets.

--- a/cmd/cariddi/main.go
+++ b/cmd/cariddi/main.go
@@ -69,25 +69,26 @@ func main() {
 	// Setup the config according to the flags that were
 	// passed via the CLI
 	config := &crawler.Scan{
-		Delay:         flags.Delay,
-		Concurrency:   flags.Concurrency,
-		Ignore:        flags.Ignore,
-		IgnoreTxt:     flags.IgnoreTXT,
-		Cache:         flags.Cache,
-		JSON:          flags.JSON,
-		Timeout:       flags.Timeout,
-		Intensive:     flags.Intensive,
-		Rua:           flags.Rua,
-		Proxy:         flags.Proxy,
-		SecretsFlag:   flags.Secrets,
-		Plain:         flags.Plain,
-		EndpointsFlag: flags.Endpoints,
-		FileType:      flags.Extensions,
-		ErrorsFlag:    flags.Errors,
-		InfoFlag:      flags.Info,
-		Debug:         flags.Debug,
-		UserAgent:     flags.UserAgent,
-		StoreResp:     flags.StoreResp,
+		Delay:          flags.Delay,
+		Concurrency:    flags.Concurrency,
+		Ignore:         flags.Ignore,
+		IgnoreTxt:      flags.IgnoreTXT,
+		Cache:          flags.Cache,
+		JSON:           flags.JSON,
+		Timeout:        flags.Timeout,
+		Intensive:      flags.Intensive,
+		Rua:            flags.Rua,
+		Proxy:          flags.Proxy,
+		SecretsFlag:    flags.Secrets,
+		Plain:          flags.Plain,
+		EndpointsFlag:  flags.Endpoints,
+		FileType:       flags.Extensions,
+		ErrorsFlag:     flags.Errors,
+		InfoFlag:       flags.Info,
+		Debug:          flags.Debug,
+		UserAgent:      flags.UserAgent,
+		StoreResp:      flags.StoreResp,
+		StoredRespPath: flags.StoredRespDir,
 	}
 
 	// Read the targets from standard input.
@@ -118,18 +119,18 @@ func main() {
 	// Create output files if needed (txt / html).
 	config.Txt = ""
 	if flags.TXTout != "" {
-		config.Txt = fileUtils.CreateOutputFile(flags.TXTout, "results", "txt")
+		config.Txt = fileUtils.CreateOutputFile(flags.TXTout, "results", "txt", config.StoredRespPath)
 	}
 
 	var ResultHTML = ""
 	if flags.HTMLout != "" {
-		ResultHTML = fileUtils.CreateOutputFile(flags.HTMLout, "", "html")
+		ResultHTML = fileUtils.CreateOutputFile(flags.HTMLout, "", "html", config.StoredRespPath)
 		output.BannerHTML(ResultHTML)
 		output.HeaderHTML("Results", ResultHTML)
 	}
 
 	if config.StoreResp {
-		fileUtils.CreateIndexOutputFile("index.responses.txt")
+		fileUtils.CreateIndexOutputFile("index.responses.txt", config.StoredRespPath)
 	}
 
 	// Read headers if needed

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -42,11 +42,16 @@ const (
 	Permission0644 = 0644
 )
 
+// constant defined in output.go as well, for circular dependency
+const (
+	CariddiOutputFolder = "output-cariddi"
+)
+
 // CreateOutputFolder creates the output folder
 // If it fails exits with an error message.
-func CreateOutputFolder() {
+func CreateOutputFolder(outputDir string) {
 	// Create a folder/directory at a full qualified path
-	err := os.Mkdir("output-cariddi", Permission0755)
+	err := os.MkdirAll(outputDir, Permission0755)
 	if err != nil {
 		fmt.Println("Can't create output folder.")
 		os.Exit(1)
@@ -56,9 +61,9 @@ func CreateOutputFolder() {
 // CreateHostOutputFolder creates the host output folder
 // for the HTTP responses.
 // If it fails exits with an error message.
-func CreateHostOutputFolder(host string) {
+func CreateHostOutputFolder(host string, outputDir string) {
 	// Create a folder/directory at a full qualified path
-	err := os.MkdirAll(filepath.Join("output-cariddi", host), Permission0755)
+	err := os.MkdirAll(filepath.Join(outputDir, host), Permission0755)
 	if err != nil {
 		fmt.Println("Can't create host output folder.")
 		os.Exit(1)
@@ -71,21 +76,25 @@ func CreateHostOutputFolder(host string) {
 // already exists, if yes asks the user if cariddi has to overwrite it;
 // if no cariddi creates it.
 // Whenever an instruction fails, it exits with an error message.
-func CreateOutputFile(target string, subcommand string, format string) string {
+func CreateOutputFile(target string, subcommand string, format string, outputDir string) string {
+	if outputDir == "" {
+		outputDir = CariddiOutputFolder
+	}
+
 	target = ReplaceBadCharacterOutput(target)
 
 	var filename string
 	if subcommand != "" {
-		filename = filepath.Join("output-cariddi", target+"."+subcommand+"."+format)
+		filename = filepath.Join(outputDir, target+"."+subcommand+"."+format)
 	} else {
-		filename = filepath.Join("output-cariddi", target+"."+format)
+		filename = filepath.Join(outputDir, target+"."+format)
 	}
 
 	_, err := os.Stat(filename)
 
 	if os.IsNotExist(err) {
-		if _, err := os.Stat("output-cariddi/"); os.IsNotExist(err) {
-			CreateOutputFolder()
+		if _, err := os.Stat(outputDir + "/"); os.IsNotExist(err) {
+			CreateOutputFolder(outputDir)
 		}
 		// If the file doesn't exist, create it.
 		f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, Permission0644)
@@ -119,15 +128,19 @@ func CreateOutputFile(target string, subcommand string, format string) string {
 // It creates the output folder if needed, then checks if the index output file
 // already exists, if no cariddi creates it.
 // Whenever an instruction fails, it exits with an error message.
-func CreateIndexOutputFile(filename string) {
+func CreateIndexOutputFile(filename string, outputDir string) {
+	if outputDir == "" {
+		outputDir = CariddiOutputFolder
+	}
+
 	_, err := os.Stat(filename)
 
 	if os.IsNotExist(err) {
-		if _, err := os.Stat("output-cariddi/"); os.IsNotExist(err) {
-			CreateOutputFolder()
+		if _, err := os.Stat(outputDir + "/"); os.IsNotExist(err) {
+			CreateOutputFolder(outputDir)
 		}
 		// If the file doesn't exist, create it.
-		filename = filepath.Join("output-cariddi", filename)
+		filename = filepath.Join(outputDir, filename)
 
 		f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, Permission0644)
 		if err != nil {

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -42,11 +42,6 @@ const (
 	Permission0644 = 0644
 )
 
-// constant defined in output.go as well, for circular dependency
-const (
-	CariddiOutputFolder = "output-cariddi"
-)
-
 // CreateOutputFolder creates the output folder
 // If it fails exits with an error message.
 func CreateOutputFolder(outputDir string) {
@@ -77,10 +72,6 @@ func CreateHostOutputFolder(host string, outputDir string) {
 // if no cariddi creates it.
 // Whenever an instruction fails, it exits with an error message.
 func CreateOutputFile(target string, subcommand string, format string, outputDir string) string {
-	if outputDir == "" {
-		outputDir = CariddiOutputFolder
-	}
-
 	target = ReplaceBadCharacterOutput(target)
 
 	var filename string
@@ -129,10 +120,6 @@ func CreateOutputFile(target string, subcommand string, format string, outputDir
 // already exists, if no cariddi creates it.
 // Whenever an instruction fails, it exits with an error message.
 func CreateIndexOutputFile(filename string, outputDir string) {
-	if outputDir == "" {
-		outputDir = CariddiOutputFolder
-	}
-
 	_, err := os.Stat(filename)
 
 	if os.IsNotExist(err) {

--- a/pkg/crawler/colly.go
+++ b/pkg/crawler/colly.go
@@ -134,8 +134,17 @@ func New(scan *Scan) *Results {
 			fmt.Println(r.Request.URL)
 		}
 
-		if scan.StoreResp {
-			err := output.StoreHTTPResponse(r)
+		var outputPath string
+
+		if scan.StoreResp || len(scan.StoredRespPath) > 0 {
+			outputDir := scan.StoredRespPath
+
+			if outputDir == "" {
+				outputDir = output.CariddiOutputFolder
+			}
+
+			var err error
+			outputPath, err = output.StoreHTTPResponse(r, outputDir)
 			if err != nil {
 				log.Println(err)
 			}
@@ -193,7 +202,7 @@ func New(scan *Scan) *Results {
 
 		if scan.JSON {
 			jsonOutput, err := output.GetJSONString(
-				r, secrets, parameters, filetype, errors, infos,
+				r, secrets, parameters, filetype, errors, infos, outputPath,
 			)
 
 			if err == nil {

--- a/pkg/crawler/colly.go
+++ b/pkg/crawler/colly.go
@@ -136,15 +136,9 @@ func New(scan *Scan) *Results {
 
 		var outputPath string
 
-		if scan.StoreResp || len(scan.StoredRespPath) > 0 {
-			outputDir := scan.StoredRespPath
-
-			if outputDir == "" {
-				outputDir = output.CariddiOutputFolder
-			}
-
+		if scan.StoreResp {
 			var err error
-			outputPath, err = output.StoreHTTPResponse(r, outputDir)
+			outputPath, err = output.StoreHTTPResponse(r, scan.OutputDir)
 			if err != nil {
 				log.Println(err)
 			}

--- a/pkg/crawler/options.go
+++ b/pkg/crawler/options.go
@@ -39,26 +39,27 @@ type Results struct {
 
 type Scan struct {
 	// Flags
-	Cache         bool
-	Debug         bool
-	EndpointsFlag bool
-	ErrorsFlag    bool
-	InfoFlag      bool
-	Intensive     bool
-	Plain         bool
-	Rua           bool
-	SecretsFlag   bool
-	Ignore        string
-	IgnoreTxt     string
-	JSON          bool
-	HTML          string
-	Proxy         string
-	Target        string
-	Txt           string
-	UserAgent     string
-	FileType      int
-	Headers       map[string]string
-	StoreResp     bool
+	Cache          bool
+	Debug          bool
+	EndpointsFlag  bool
+	ErrorsFlag     bool
+	InfoFlag       bool
+	Intensive      bool
+	Plain          bool
+	Rua            bool
+	SecretsFlag    bool
+	Ignore         string
+	IgnoreTxt      string
+	JSON           bool
+	HTML           string
+	Proxy          string
+	Target         string
+	Txt            string
+	UserAgent      string
+	FileType       int
+	Headers        map[string]string
+	StoreResp      bool
+	StoredRespPath string
 
 	// Settings
 	Concurrency int

--- a/pkg/crawler/options.go
+++ b/pkg/crawler/options.go
@@ -39,27 +39,27 @@ type Results struct {
 
 type Scan struct {
 	// Flags
-	Cache          bool
-	Debug          bool
-	EndpointsFlag  bool
-	ErrorsFlag     bool
-	InfoFlag       bool
-	Intensive      bool
-	Plain          bool
-	Rua            bool
-	SecretsFlag    bool
-	Ignore         string
-	IgnoreTxt      string
-	JSON           bool
-	HTML           string
-	Proxy          string
-	Target         string
-	Txt            string
-	UserAgent      string
-	FileType       int
-	Headers        map[string]string
-	StoreResp      bool
-	StoredRespPath string
+	Cache         bool
+	Debug         bool
+	EndpointsFlag bool
+	ErrorsFlag    bool
+	InfoFlag      bool
+	Intensive     bool
+	Plain         bool
+	Rua           bool
+	SecretsFlag   bool
+	Ignore        string
+	IgnoreTxt     string
+	JSON          bool
+	HTML          string
+	Proxy         string
+	Target        string
+	Txt           string
+	UserAgent     string
+	FileType      int
+	Headers       map[string]string
+	StoreResp     bool
+	OutputDir     string
 
 	// Settings
 	Concurrency int

--- a/pkg/input/flags.go
+++ b/pkg/input/flags.go
@@ -94,6 +94,8 @@ type Input struct {
 	UserAgent string
 	// StoreResp stores HTTP responses.
 	StoreResp bool
+	// StoredRespDir stores HTTP responses to the directory provided.
+	StoredRespDir string
 }
 
 // ScanFlag defines all the options taken
@@ -142,6 +144,8 @@ func ScanFlag() Input {
 
 	storeRespPtr := flag.Bool("sr", false, "Store HTTP responses.")
 
+	storedRespDirPtr := flag.String("srd", "", "Stores HTTP responses to the directory provided.")
+
 	flag.Parse()
 
 	result := Input{
@@ -173,6 +177,7 @@ func ScanFlag() Input {
 		*debugPtr,
 		*userAgentPtr,
 		*storeRespPtr,
+		*storedRespDirPtr,
 	}
 
 	return result

--- a/pkg/output/jsonl.go
+++ b/pkg/output/jsonl.go
@@ -44,6 +44,7 @@ type JSONData struct {
 	ContentType   string          `json:"content_type,omitempty"`
 	ContentLength int             `json:"content_length,omitempty"`
 	Matches       *MatcherResults `json:"matches,omitempty"`
+	OutputPath    string          `json:"output_path,omitempty"`
 	// Host          string `json:"host"` # TODO: Available in Colly 2.x
 }
 
@@ -67,6 +68,7 @@ func GetJSONString(
 	filetype *scanner.FileType,
 	errors []scanner.ErrorMatched,
 	infos []scanner.InfoMatched,
+	outputPath string,
 ) ([]byte, error) {
 	// Parse response headers
 	headers := r.Headers
@@ -136,6 +138,7 @@ func GetJSONString(
 		ContentType:   contentType,
 		ContentLength: contentLength,
 		Matches:       matcherResults,
+		OutputPath:    outputPath,
 		// Host:          "", // TODO
 	}
 

--- a/pkg/output/jsonl_test.go
+++ b/pkg/output/jsonl_test.go
@@ -113,6 +113,7 @@ func TestJSONOutput(t *testing.T) {
 		errors     []scanner.ErrorMatched
 		infos      []scanner.InfoMatched
 		want       string
+		outputPath string
 	}{
 		{
 			name:       "test_all_findings",
@@ -123,6 +124,7 @@ func TestJSONOutput(t *testing.T) {
 			errors:     errors,
 			infos:      infos,
 			want:       `{"url":"http://test.com.pdf?id=5","method":"GET","status_code":200,"words":1,"lines":1,"content_type":"application/pdf","content_length":128,"matches":{"filetype":{"extension":"pdf","severity":7},"parameters":[{"name":"id","attacks":[]}],"errors":[{"name":"MySQL error","match":"it is a MySQL error happening"}],"infos":[{"name":"info1","match":"its my pleasure to inform you on this great day"}],"secrets":[{"name":"mysecret","match":"it's a random day for my secret regex to be found"}]}}`, //nolint:lll
+			outputPath: "C:\\testDir1\\testDir2",
 		},
 		{
 			name:       "test_all_findings_nocontent",
@@ -133,6 +135,7 @@ func TestJSONOutput(t *testing.T) {
 			errors:     errors,
 			infos:      infos,
 			want:       `{"url":"http://test.com.pdf?id=5","method":"GET","status_code":200,"words":1,"lines":1,"matches":{"filetype":{"extension":"pdf","severity":7},"parameters":[{"name":"id","attacks":[]}],"errors":[{"name":"MySQL error","match":"it is a MySQL error happening"}],"infos":[{"name":"info1","match":"its my pleasure to inform you on this great day"}],"secrets":[{"name":"mysecret","match":"it's a random day for my secret regex to be found"}]}}`, //nolint:lll
+			outputPath: "C:\\testDir1\\testDir2",
 		},
 		{
 			name:       "test_no_findings",
@@ -143,6 +146,7 @@ func TestJSONOutput(t *testing.T) {
 			errors:     []scanner.ErrorMatched{},
 			infos:      []scanner.InfoMatched{},
 			want:       `{"url":"http://test.com.pdf?id=5","method":"GET","status_code":200,"words":1,"lines":1,"content_type":"application/pdf","content_length":128}`, //nolint: all
+			outputPath: "C:\\testDir1\\testDir2",
 		},
 		{
 			name:       "test_only_secrets",
@@ -153,6 +157,7 @@ func TestJSONOutput(t *testing.T) {
 			errors:     []scanner.ErrorMatched{},
 			infos:      []scanner.InfoMatched{},
 			want:       `{"url":"http://test.com.pdf?id=5","method":"GET","status_code":200,"words":1,"lines":1,"content_type":"application/pdf","content_length":128,"matches":{"secrets":[{"name":"mysecret","match":"it's a random day for my secret regex to be found"}]}}`, //nolint:lll
+			outputPath: "C:\\testDir1\\testDir2",
 		},
 		{
 			name:       "test_only_params",
@@ -163,6 +168,7 @@ func TestJSONOutput(t *testing.T) {
 			errors:     []scanner.ErrorMatched{},
 			infos:      []scanner.InfoMatched{},
 			want:       `{"url":"http://test.com.pdf?id=5","method":"GET","status_code":200,"words":1,"lines":1,"content_type":"application/pdf","content_length":128,"matches":{"parameters":[{"name":"id","attacks":[]}]}}`, //nolint:lll
+			outputPath: "C:\\testDir1\\testDir2",
 		},
 		{
 			name:       "test_only_errors",
@@ -173,6 +179,7 @@ func TestJSONOutput(t *testing.T) {
 			errors:     errors,
 			infos:      []scanner.InfoMatched{},
 			want:       `{"url":"http://test.com.pdf?id=5","method":"GET","status_code":200,"words":1,"lines":1,"content_type":"application/pdf","content_length":128,"matches":{"errors":[{"name":"MySQL error","match":"it is a MySQL error happening"}]}}`, //nolint:lll
+			outputPath: "C:\\testDir1\\testDir2",
 		},
 		{
 			name:       "test_only_infos",
@@ -183,12 +190,24 @@ func TestJSONOutput(t *testing.T) {
 			errors:     []scanner.ErrorMatched{},
 			infos:      infos,
 			want:       `{"url":"http://test.com.pdf?id=5","method":"GET","status_code":200,"words":1,"lines":1,"content_type":"application/pdf","content_length":128,"matches":{"infos":[{"name":"info1","match":"its my pleasure to inform you on this great day"}]}}`, //nolint:lll
+			outputPath: "C:\\testDir1\\testDir2",
+		},
+		{
+			name:       "test_no_outputPath",
+			r:          resp,
+			secrets:    []scanner.SecretMatched{},
+			parameters: []scanner.Parameter{},
+			filetype:   &scanner.FileType{},
+			errors:     []scanner.ErrorMatched{},
+			infos:      infos,
+			want:       `{"url":"http://test.com.pdf?id=5","method":"GET","status_code":200,"words":1,"lines":1,"content_type":"application/pdf","content_length":128,"matches":{"infos":[{"name":"info1","match":"its my pleasure to inform you on this great day"}]}}`, //nolint:lll
+			outputPath: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, _ := output.GetJSONString(tt.r, tt.secrets, tt.parameters, tt.filetype, tt.errors, tt.infos); !reflect.DeepEqual(string(got), tt.want) { //nolint:lll
+			if got, _ := output.GetJSONString(tt.r, tt.secrets, tt.parameters, tt.filetype, tt.errors, tt.infos, tt.outputPath); !reflect.DeepEqual(string(got), tt.want) { //nolint:lll
 				t.Errorf("GetJSONString\n%v", string(got))
 				t.Errorf("want\n%v", tt.want)
 			}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -52,12 +52,7 @@ func PrintSimpleOutput(out []string) {
 // Actually it manages everything related to TXT output.
 func TxtOutput(flags input.Input, finalResults []string, finalSecret []scanner.SecretMatched,
 	finalEndpoints []scanner.EndpointMatched, finalExtensions []scanner.FileTypeMatched,
-	finalErrors []scanner.ErrorMatched, finalInfos []scanner.InfoMatched) {
-
-	outputDir := CariddiOutputFolder
-	if flags.StoredRespDir != "" {
-		outputDir = flags.StoredRespDir
-	}
+	finalErrors []scanner.ErrorMatched, finalInfos []scanner.InfoMatched, outputDir string) {
 
 	exists, err := fileUtils.ElementExists(outputDir)
 	if err != nil {
@@ -130,12 +125,7 @@ func TxtOutput(flags input.Input, finalResults []string, finalSecret []scanner.S
 // Actually it manages everything related to HTML output.
 func HTMLOutput(flags input.Input, resultFilename string, finalResults []string, finalSecret []scanner.SecretMatched,
 	finalEndpoints []scanner.EndpointMatched, finalExtensions []scanner.FileTypeMatched,
-	finalErrors []scanner.ErrorMatched, finalInfos []scanner.InfoMatched) {
-
-	outputDir := CariddiOutputFolder
-	if flags.StoredRespDir != "" {
-		outputDir = flags.StoredRespDir
-	}
+	finalErrors []scanner.ErrorMatched, finalInfos []scanner.InfoMatched, outputDir string) {
 
 	exists, err := fileUtils.ElementExists(outputDir)
 

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -36,6 +36,7 @@ import (
 	"github.com/edoardottt/cariddi/pkg/scanner"
 )
 
+// constant defined in file.go as well, for circular dependency
 const (
 	CariddiOutputFolder = "output-cariddi"
 )
@@ -52,24 +53,30 @@ func PrintSimpleOutput(out []string) {
 func TxtOutput(flags input.Input, finalResults []string, finalSecret []scanner.SecretMatched,
 	finalEndpoints []scanner.EndpointMatched, finalExtensions []scanner.FileTypeMatched,
 	finalErrors []scanner.ErrorMatched, finalInfos []scanner.InfoMatched) {
-	exists, err := fileUtils.ElementExists(CariddiOutputFolder)
+
+	outputDir := CariddiOutputFolder
+	if flags.StoredRespDir != "" {
+		outputDir = flags.StoredRespDir
+	}
+
+	exists, err := fileUtils.ElementExists(outputDir)
 	if err != nil {
 		fmt.Println("Error while creating the output directory.")
 		os.Exit(1)
 	}
 
 	if !exists {
-		fileUtils.CreateOutputFolder()
+		fileUtils.CreateOutputFolder(outputDir)
 	}
 
-	ResultFilename := fileUtils.CreateOutputFile(flags.TXTout, "results", "txt")
+	ResultFilename := fileUtils.CreateOutputFile(flags.TXTout, "results", "txt", outputDir)
 	for _, elem := range finalResults {
 		AppendOutputToTxt(elem, ResultFilename)
 	}
 
 	// if secrets flag enabled save also secrets
 	if flags.Secrets {
-		SecretFilename := fileUtils.CreateOutputFile(flags.TXTout, "secrets", "txt")
+		SecretFilename := fileUtils.CreateOutputFile(flags.TXTout, "secrets", "txt", outputDir)
 		for _, elem := range finalSecret {
 			AppendOutputToTxt(fmt.Sprintf("%s - %s in %s", elem.Secret.Name, elem.Match, elem.URL), SecretFilename)
 		}
@@ -77,7 +84,7 @@ func TxtOutput(flags input.Input, finalResults []string, finalSecret []scanner.S
 
 	// if endpoints flag enabled save also endpoints
 	if flags.Endpoints {
-		EndpointFilename := fileUtils.CreateOutputFile(flags.TXTout, "endpoints", "txt")
+		EndpointFilename := fileUtils.CreateOutputFile(flags.TXTout, "endpoints", "txt", outputDir)
 
 		for _, elem := range finalEndpoints {
 			for _, parameter := range elem.Parameters {
@@ -96,7 +103,7 @@ func TxtOutput(flags input.Input, finalResults []string, finalSecret []scanner.S
 
 	// if extensions flag enabled save also secrets
 	if 1 <= flags.Extensions && flags.Extensions <= 7 {
-		ExtensionsFilename := fileUtils.CreateOutputFile(flags.TXTout, "extensions", "txt")
+		ExtensionsFilename := fileUtils.CreateOutputFile(flags.TXTout, "extensions", "txt", outputDir)
 		for _, elem := range finalExtensions {
 			AppendOutputToTxt(fmt.Sprintf("%s in %s", elem.Filetype.Extension, elem.URL), ExtensionsFilename)
 		}
@@ -104,7 +111,7 @@ func TxtOutput(flags input.Input, finalResults []string, finalSecret []scanner.S
 
 	// if errors flag enabled save also errors
 	if flags.Errors {
-		ErrorsFilename := fileUtils.CreateOutputFile(flags.TXTout, "errors", "txt")
+		ErrorsFilename := fileUtils.CreateOutputFile(flags.TXTout, "errors", "txt", outputDir)
 		for _, elem := range finalErrors {
 			AppendOutputToTxt(fmt.Sprintf("%s - %s in %s", elem.Error.ErrorName, elem.Match, elem.URL), ErrorsFilename)
 		}
@@ -112,7 +119,7 @@ func TxtOutput(flags input.Input, finalResults []string, finalSecret []scanner.S
 
 	// if info flag enabled save also infos
 	if flags.Info {
-		InfosFilename := fileUtils.CreateOutputFile(flags.TXTout, "info", "txt")
+		InfosFilename := fileUtils.CreateOutputFile(flags.TXTout, "info", "txt", outputDir)
 		for _, elem := range finalInfos {
 			AppendOutputToTxt(fmt.Sprintf("%s - %s in %s", elem.Info.Name, elem.Match, elem.URL), InfosFilename)
 		}
@@ -124,7 +131,13 @@ func TxtOutput(flags input.Input, finalResults []string, finalSecret []scanner.S
 func HTMLOutput(flags input.Input, resultFilename string, finalResults []string, finalSecret []scanner.SecretMatched,
 	finalEndpoints []scanner.EndpointMatched, finalExtensions []scanner.FileTypeMatched,
 	finalErrors []scanner.ErrorMatched, finalInfos []scanner.InfoMatched) {
-	exists, err := fileUtils.ElementExists(CariddiOutputFolder)
+
+	outputDir := CariddiOutputFolder
+	if flags.StoredRespDir != "" {
+		outputDir = flags.StoredRespDir
+	}
+
+	exists, err := fileUtils.ElementExists(outputDir)
 
 	if err != nil {
 		fmt.Println("Error while creating the output directory.")
@@ -132,7 +145,7 @@ func HTMLOutput(flags input.Input, resultFilename string, finalResults []string,
 	}
 
 	if !exists {
-		fileUtils.CreateOutputFolder()
+		fileUtils.CreateOutputFolder(outputDir)
 	}
 
 	HeaderHTML("Results found", resultFilename)


### PR DESCRIPTION
Fixes #129 
The code changes include new -srd flag. The directory will be used to save all the output files, such textOutput, htmlOutput, indexResponses and raw response. Earlier all these file used to be saved in the "output-cariddi" in the same directory.

Fixes #130 
The output path of the stored response will also be printed in the json output if -json flag is enabled