### PR TITLE
Update GoReleaser configuration

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,7 +33,7 @@ builds:
     main: ./cmd/cariddi/
 
 archives:
-- format: zip
+- formats: [zip]
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}'
 
 checksum:


### PR DESCRIPTION
#### Summary
This small PR updates the GoReleaser configuration to resolve the following warnings: 
```
DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```