### PR TITLE
feat: add -scheme flag to choose http/https for scheme-less targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Default: png, svg, jpg, jpeg, bmp, jfif, gif, webp, woff, woff2, ttf, tiff, tif,
 - `cat domains.txt | cariddi -scheme auto` (For targets without a scheme, try https then fall back to http, this is the default)
 - `cat domains.txt | cariddi -scheme https` (Force the https scheme for targets without one)
 
-Targets that already include a scheme (e.g. `https://example.com`) are always crawled as-is; the `-scheme` flag only affects scheme-less targets such as a plain list of FQDNs.
+Targets that already include a scheme (e.g. `https://example.com`) are always crawled as-is; the `-scheme` flag only affects scheme-less targets such as a plain list of FQDNs. A scheme-less target that does not resolve (no IP) or whose web port is closed (nothing on 443/80 for the chosen mode) is skipped instead of being crawled, and cariddi moves on to the next target.
 
 ### Output
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ Default: png, svg, jpg, jpeg, bmp, jfif, gif, webp, woff, woff2, ttf, tiff, tif,
 - `cat urls.txt | cariddi -headersfile headers.txt` (Read from an external file custom headers)
 - `cat urls.txt | cariddi -ua "Custom User Agent"` (Use a custom User Agent)
 - `cat urls.txt | cariddi -rua` (Use a random browser user agent on every request)
+- `cat domains.txt | cariddi -scheme auto` (For targets without a scheme, try https then fall back to http, this is the default)
+- `cat domains.txt | cariddi -scheme https` (Force the https scheme for targets without one)
+
+Targets that already include a scheme (e.g. `https://example.com`) are always crawled as-is; the `-scheme` flag only affects scheme-less targets such as a plain list of FQDNs.
 
 ### Output
 
@@ -219,6 +223,8 @@ Usage of cariddi:
   -rua
      Use a random browser user agent on every request.
   -s Hunt for secrets.
+  -scheme string
+     Scheme to use for targets without one: auto (https then http), https or http. (default "auto")
   -sf string
      Use an external file (txt, one per line) to use custom regexes for secrets hunting.
   -sr

--- a/cmd/cariddi/main.go
+++ b/cmd/cariddi/main.go
@@ -78,6 +78,7 @@ func main() {
 		Intensive:        flags.Intensive,
 		Rua:              flags.Rua,
 		Proxy:            flags.Proxy,
+		Scheme:           flags.Scheme,
 		SecretsFlag:      flags.Secrets,
 		Plain:            flags.Plain,
 		EndpointsFlag:    flags.Endpoints,

--- a/pkg/crawler/colly.go
+++ b/pkg/crawler/colly.go
@@ -57,13 +57,16 @@ func New(scan *Scan) *Results {
 
 	results := &Results{}
 
-	// if there isn't a scheme use http.
-	if !urlUtils.HasProtocol(scan.Target) {
-		protocolTemp = "http"
-		targetTemp = urlUtils.GetHost(fmt.Sprintf("%s://%s", protocolTemp, scan.Target))
-	} else {
+	// If the target already carries a scheme, honor it as-is. Otherwise pick the
+	// scheme according to scan.Scheme (auto tries https first, then http).
+	if urlUtils.HasProtocol(scan.Target) {
 		protocolTemp = urlUtils.GetProtocol(scan.Target)
 		targetTemp = urlUtils.GetHost(scan.Target)
+	} else {
+		targetTemp = urlUtils.GetHost(scan.Target)
+		protocolTemp = ResolveProtocol(scan.Scheme, func() bool {
+			return isHTTPSReachable(targetTemp, scan)
+		})
 	}
 
 	if scan.Intensive {
@@ -334,6 +337,71 @@ func CreateColly(delayTime, concurrency, timeout, maxDepth int,
 	}
 
 	return c
+}
+
+// ResolveProtocol decides which scheme to use for a scheme-less target
+// according to the requested mode (input.SchemeAuto, input.SchemeHTTPS or
+// input.SchemeHTTP). For the auto mode the httpsReachable callback is used to
+// probe the host; it is injected so the decision can be unit-tested without
+// performing real network requests.
+func ResolveProtocol(mode string, httpsReachable func() bool) string {
+	switch mode {
+	case input.SchemeHTTP:
+		return input.SchemeHTTP
+	case input.SchemeHTTPS:
+		return input.SchemeHTTPS
+	default:
+		if httpsReachable() {
+			return input.SchemeHTTPS
+		}
+
+		return input.SchemeHTTP
+	}
+}
+
+// isHTTPSReachable probes the host over https and reports whether it answers.
+// Any HTTP response (including 4xx/5xx) counts as reachable; connection, TLS
+// or timeout errors mean it is not. It mirrors the collector TLS, proxy and
+// user-agent configuration.
+func isHTTPSReachable(host string, scan *Scan) bool {
+	transport := &http.Transport{
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+		DisableKeepAlives: true,
+	}
+
+	if scan.Proxy != "" {
+		if proxyParsed, err := url.Parse(scan.Proxy); err == nil {
+			transport.Proxy = http.ProxyURL(proxyParsed)
+		}
+	}
+
+	timeout := scan.Timeout
+	if timeout <= 0 {
+		timeout = input.TimeoutRequest
+	}
+
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   time.Duration(timeout) * time.Second,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, input.SchemeHTTPS+"://"+host, http.NoBody)
+	if err != nil {
+		return false
+	}
+
+	if scan.UserAgent != "" {
+		req.Header.Set("User-Agent", scan.UserAgent)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+
+	defer resp.Body.Close()
+
+	return true
 }
 
 // registerHTMLEvents registers the associated functions for each

--- a/pkg/crawler/colly.go
+++ b/pkg/crawler/colly.go
@@ -58,15 +58,27 @@ func New(scan *Scan) *Results {
 	results := &Results{}
 
 	// If the target already carries a scheme, honor it as-is. Otherwise pick the
-	// scheme according to scan.Scheme (auto tries https first, then http).
+	// scheme according to scan.Scheme (auto tries https first, then http) and
+	// skip the target entirely when the host is unreachable (does not resolve or
+	// no suitable web port answers), moving on to the next one.
 	if urlUtils.HasProtocol(scan.Target) {
 		protocolTemp = urlUtils.GetProtocol(scan.Target)
 		targetTemp = urlUtils.GetHost(scan.Target)
 	} else {
 		targetTemp = urlUtils.GetHost(scan.Target)
-		protocolTemp = ResolveProtocol(scan.Scheme, func() bool {
-			return isHTTPSReachable(targetTemp, scan)
+
+		proto, reachable := ResolveProtocol(scan.Scheme, func(scheme string) bool {
+			return isReachable(scheme, targetTemp, scan)
 		})
+		if !reachable {
+			if scan.Debug {
+				log.Printf("Skipping unreachable target (no DNS or no open web port): %s", scan.Target)
+			}
+
+			return results
+		}
+
+		protocolTemp = proto
 	}
 
 	if scan.Intensive {
@@ -339,31 +351,49 @@ func CreateColly(delayTime, concurrency, timeout, maxDepth int,
 	return c
 }
 
-// ResolveProtocol decides which scheme to use for a scheme-less target
-// according to the requested mode (input.SchemeAuto, input.SchemeHTTPS or
-// input.SchemeHTTP). For the auto mode the httpsReachable callback is used to
-// probe the host; it is injected so the decision can be unit-tested without
+// ResolveProtocol decides which scheme to use for a scheme-less target and
+// whether the target is reachable at all. It returns the chosen scheme
+// ("https" or "http") with ok=true, or ("", false) when the target must be
+// skipped because the host does not resolve or no suitable web port answers:
+//
+//   - input.SchemeHTTP  -> http if port 80 answers, otherwise skip.
+//   - input.SchemeHTTPS -> https if port 443 answers, otherwise skip.
+//   - input.SchemeAuto  -> https if it answers, else http if it answers, else skip.
+//
+// The reachable callback is injected so the decision can be unit-tested without
 // performing real network requests.
-func ResolveProtocol(mode string, httpsReachable func() bool) string {
+func ResolveProtocol(mode string, reachable func(scheme string) bool) (string, bool) {
 	switch mode {
 	case input.SchemeHTTP:
-		return input.SchemeHTTP
-	case input.SchemeHTTPS:
-		return input.SchemeHTTPS
-	default:
-		if httpsReachable() {
-			return input.SchemeHTTPS
+		if reachable(input.SchemeHTTP) {
+			return input.SchemeHTTP, true
 		}
 
-		return input.SchemeHTTP
+		return "", false
+	case input.SchemeHTTPS:
+		if reachable(input.SchemeHTTPS) {
+			return input.SchemeHTTPS, true
+		}
+
+		return "", false
+	default:
+		if reachable(input.SchemeHTTPS) {
+			return input.SchemeHTTPS, true
+		}
+
+		if reachable(input.SchemeHTTP) {
+			return input.SchemeHTTP, true
+		}
+
+		return "", false
 	}
 }
 
-// isHTTPSReachable probes the host over https and reports whether it answers.
-// Any HTTP response (including 4xx/5xx) counts as reachable; connection, TLS
-// or timeout errors mean it is not. It mirrors the collector TLS, proxy and
-// user-agent configuration.
-func isHTTPSReachable(host string, scan *Scan) bool {
+// isReachable probes the host with the given scheme and reports whether it
+// answers. Any HTTP response (including 4xx/5xx) counts as reachable; DNS,
+// connection, TLS or timeout errors mean it is not. It mirrors the collector
+// TLS, proxy and user-agent configuration.
+func isReachable(scheme, host string, scan *Scan) bool {
 	transport := &http.Transport{
 		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
 		DisableKeepAlives: true,
@@ -385,7 +415,7 @@ func isHTTPSReachable(host string, scan *Scan) bool {
 		Timeout:   time.Duration(timeout) * time.Second,
 	}
 
-	req, err := http.NewRequest(http.MethodGet, input.SchemeHTTPS+"://"+host, http.NoBody)
+	req, err := http.NewRequest(http.MethodGet, scheme+"://"+host, http.NoBody)
 	if err != nil {
 		return false
 	}

--- a/pkg/crawler/options.go
+++ b/pkg/crawler/options.go
@@ -56,6 +56,7 @@ type Scan struct {
 	JSON             bool
 	HTML             string
 	Proxy            string
+	Scheme           string
 	Target           string
 	Txt              string
 	UserAgent        string

--- a/pkg/crawler/scheme_test.go
+++ b/pkg/crawler/scheme_test.go
@@ -1,0 +1,64 @@
+/*
+==========
+Cariddi
+==========
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see http://www.gnu.org/licenses/.
+
+	@Repository:  https://github.com/edoardottt/cariddi
+
+	@Author:      edoardottt, https://edoardottt.com
+
+	@License: https://github.com/edoardottt/cariddi/blob/main/LICENSE
+
+*/
+
+package crawler_test
+
+import (
+	"testing"
+
+	"github.com/edoardottt/cariddi/pkg/crawler"
+	"github.com/edoardottt/cariddi/pkg/input"
+)
+
+func TestResolveProtocol(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		mode      string
+		reachable bool
+		expected  string
+	}{
+		{"http mode forces http", input.SchemeHTTP, true, "http"},
+		{"https mode forces https", input.SchemeHTTPS, false, "https"},
+		{"auto uses https when reachable", input.SchemeAuto, true, "https"},
+		{"auto falls back to http when unreachable", input.SchemeAuto, false, "http"},
+		{"empty mode behaves like auto (reachable)", "", true, "https"},
+		{"empty mode behaves like auto (unreachable)", "", false, "http"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := crawler.ResolveProtocol(tt.mode, func() bool { return tt.reachable })
+			if got != tt.expected {
+				t.Errorf("ResolveProtocol(mode=%q, reachable=%v) = %q; want %q",
+					tt.mode, tt.reachable, got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/crawler/scheme_test.go
+++ b/pkg/crawler/scheme_test.go
@@ -37,27 +37,43 @@ func TestResolveProtocol(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		mode      string
-		reachable bool
-		expected  string
+		name       string
+		mode       string
+		httpsUp    bool
+		httpUp     bool
+		wantScheme string
+		wantOK     bool
 	}{
-		{"http mode forces http", input.SchemeHTTP, true, "http"},
-		{"https mode forces https", input.SchemeHTTPS, false, "https"},
-		{"auto uses https when reachable", input.SchemeAuto, true, "https"},
-		{"auto falls back to http when unreachable", input.SchemeAuto, false, "http"},
-		{"empty mode behaves like auto (reachable)", "", true, "https"},
-		{"empty mode behaves like auto (unreachable)", "", false, "http"},
+		{"auto prefers https when both up", input.SchemeAuto, true, true, "https", true},
+		{"auto uses https when only https up", input.SchemeAuto, true, false, "https", true},
+		{"auto falls back to http when only http up", input.SchemeAuto, false, true, "http", true},
+		{"auto skips when nothing up", input.SchemeAuto, false, false, "", false},
+		{"empty mode behaves like auto", "", false, true, "http", true},
+		{"https crawls when 443 up", input.SchemeHTTPS, true, false, "https", true},
+		{"https skips when 443 down", input.SchemeHTTPS, false, true, "", false},
+		{"http crawls when 80 up", input.SchemeHTTP, false, true, "http", true},
+		{"http skips when 80 down", input.SchemeHTTP, true, false, "", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := crawler.ResolveProtocol(tt.mode, func() bool { return tt.reachable })
-			if got != tt.expected {
-				t.Errorf("ResolveProtocol(mode=%q, reachable=%v) = %q; want %q",
-					tt.mode, tt.reachable, got, tt.expected)
+			reachable := func(scheme string) bool {
+				switch scheme {
+				case input.SchemeHTTPS:
+					return tt.httpsUp
+				case input.SchemeHTTP:
+					return tt.httpUp
+				default:
+					return false
+				}
+			}
+
+			gotScheme, gotOK := crawler.ResolveProtocol(tt.mode, reachable)
+			if gotScheme != tt.wantScheme || gotOK != tt.wantOK {
+				t.Errorf("ResolveProtocol(mode=%q, httpsUp=%v, httpUp=%v) = (%q, %v); want (%q, %v)",
+					tt.mode, tt.httpsUp, tt.httpUp, gotScheme, gotOK, tt.wantScheme, tt.wantOK)
 			}
 		})
 	}

--- a/pkg/input/check.go
+++ b/pkg/input/check.go
@@ -132,4 +132,9 @@ func CheckFlags(flags Input) {
 		fmt.Println("MaxDepth cannot be less than 0.")
 		os.Exit(1)
 	}
+
+	if flags.Scheme != SchemeAuto && flags.Scheme != SchemeHTTPS && flags.Scheme != SchemeHTTP {
+		fmt.Println("The scheme value must be one of: auto, https, http.")
+		os.Exit(1)
+	}
 }

--- a/pkg/input/flags.go
+++ b/pkg/input/flags.go
@@ -37,6 +37,13 @@ const (
 		"mp3,wav,flac,ogg,m4a,aac," + // Audio
 		"ico,cur,eot,otf" // More icons/fonts
 	TimeoutRequest = 10
+
+	// SchemeAuto probes https first and falls back to http for scheme-less targets.
+	SchemeAuto = "auto"
+	// SchemeHTTPS forces the https scheme for scheme-less targets.
+	SchemeHTTPS = "https"
+	// SchemeHTTP forces the http scheme for scheme-less targets.
+	SchemeHTTP = "http"
 )
 
 // Input struct.
@@ -104,6 +111,8 @@ type Input struct {
 	// (Default: png, svg, jpg, jpeg, bmp, jfif, gif, webp, woff, woff2, ttf, tiff, tif, mp4,
 	// webm, mkv, avi, mov, flv, wmv, mp3, wav, flac, ogg, m4a, aac, ico, cur, eot, otf)
 	IgnoreExtensions StringSlice
+	// Scheme selects the URL scheme used for targets without one: auto, https or http.
+	Scheme string
 }
 
 // ScanFlag defines all the options taken
@@ -154,6 +163,9 @@ func ScanFlag() Input {
 
 	maxDepth := flag.Int("md", 0, "Maximum depth level the crawler will follow from the initial target URL.")
 
+	schemePtr := flag.String("scheme", SchemeAuto,
+		"Scheme to use for targets without one: auto (https then http), https or http.")
+
 	var ignoreExtensions StringSlice
 
 	flag.Var(&ignoreExtensions, "ie", "Comma-separated list of extensions to ignore while scanning")
@@ -196,6 +208,7 @@ func ScanFlag() Input {
 		*storeRespPtr,
 		*maxDepth,
 		ignoreExtensions,
+		*schemePtr,
 	}
 
 	return result

--- a/pkg/output/examples.go
+++ b/pkg/output/examples.go
@@ -90,5 +90,9 @@ func PrintExamples() {
 
 	cat urls | cariddi -md 3 (Max 3 levels)
 
-	cat urls | cariddi -ie pdf,png,jpg (Ignore these extensions while scanning)`)
+	cat urls | cariddi -ie pdf,png,jpg (Ignore these extensions while scanning)
+
+	cat domains | cariddi -scheme auto (For targets without a scheme, try https then fall back to http (default))
+
+	cat domains | cariddi -scheme https (Force the https scheme for targets without one)`)
 }

--- a/pkg/output/help.go
+++ b/pkg/output/help.go
@@ -79,6 +79,8 @@ func PrintHelp() {
 	-rua
 		Use a random browser user agent on every request.
 	-s	Hunt for secrets.
+	-scheme string
+		Scheme to use for targets without one: auto (https then http), https or http. (default "auto")
 	-sf string
 		Use an external file (txt, one per line) to use custom regexes for secrets hunting.
 	-sr


### PR DESCRIPTION
## Summary

When cariddi is fed a plain list of FQDNs (targets without a scheme), each bare host is currently **hardcoded to `http://`** ([`pkg/crawler/colly.go`](https://github.com/edoardottt/cariddi/blob/main/pkg/crawler/colly.go)):

```go
if !urlUtils.HasProtocol(scan.Target) {
    protocolTemp = "http"
    ...
}
```

This PR adds a `-scheme` flag that controls which scheme is used for scheme-less targets, and skips hosts that are not reachable:

| Value | Behavior |
|-------|----------|
| `auto` | **(default)** `https://` if it answers, else `http://` if it answers, else **skip** the target |
| `https` | `https://` if port 443 answers, else **skip** |
| `http` | `http://` if port 80 answers, else **skip** (this was the previous default scheme) |

Targets that already carry a scheme (e.g. `https://example.com`) are still crawled exactly as-is — the flag only affects scheme-less inputs, which is the common case when piping a list of domains.

```console
cat domains.txt | cariddi -scheme auto    # https then http, skip if dead (default)
cat domains.txt | cariddi -scheme https   # force https
cat domains.txt | cariddi -scheme http    # force http (old scheme behavior)
```

### Skip unreachable targets

A scheme-less target that **does not resolve (no IP)** or whose **web port is closed** (nothing answers on 443/80 for the chosen mode) is now skipped instead of being crawled — cariddi moves on to the next target rather than emitting requests for `sitemap.xml`/`/` against a dead host. With `-debug` the skip is logged.

## Notes

- **Behavior change:** the default for scheme-less targets moves from "always `http`, always crawl" to "`auto` (https-first) + skip-if-unreachable". Reproducing the old scheme is `-scheme http` (though dead hosts are still skipped). Happy to adjust if you'd prefer the new behavior to be strictly opt-in.
- The reachability probe performs a lightweight `GET <scheme>://host` and mirrors the collector's existing TLS / proxy / user-agent configuration, treating any HTTP response (including 4xx/5xx) as "reachable". It reuses the same `InsecureSkipVerify: true` the collector already sets, so a host reachable by the crawler isn't wrongly rejected by the probe.
- The scheme/skip decision is factored into the pure, exported `crawler.ResolveProtocol(mode, reachable) (scheme string, ok bool)` and unit-tested (`pkg/crawler/scheme_test.go`) with an injected reachability func, so the tests do no network I/O.

## Testing

- `gofmt`, `go vet ./...`, `go build ./...` — clean
- `go test ./...` — pass (incl. `TestResolveProtocol` covering the skip cases)
- `golangci-lint run` — **0 issues**
- Manual: `auto` resolves a live host to `https://…`; a non-resolving host produces no output and the run continues to the next target; `-scheme https` forces https; an invalid value is rejected with a clear error.

## Files changed

- `pkg/input/flags.go` — new `-scheme` flag (default `auto`) + `Scheme` field + scheme constants
- `pkg/input/check.go` — validate the flag value
- `pkg/crawler/options.go` — `Scheme` on the `Scan` config
- `cmd/cariddi/main.go` — wire the flag into the config
- `pkg/crawler/colly.go` — scheme resolution + skip logic (`ResolveProtocol` / `isReachable` helpers)
- `pkg/crawler/scheme_test.go` — unit tests
- `README.md`, `pkg/output/help.go`, `pkg/output/examples.go` — docs