### PR TITLE
feat: add global request rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Default: png, svg, jpg, jpeg, bmp, jfif, gif, webp, woff, woff2, ttf, tiff, tif,
 
 - `cat urls.txt | cariddi -proxy http://127.0.0.1:8080` (Set a Proxy, http and socks5 supported)
 - `cat urls.txt | cariddi -d 2` (2 seconds between a page crawled and another)
+- `cat urls.txt | cariddi -rl 10` (Limit all concurrent workers to 10 requests per second; `-rate-limit` is also accepted)
 - `cat urls.txt | cariddi -c 200` (Set the concurrency level to 200)
 - `cat urls.txt | cariddi -i forum,blog,community,open` (Ignore urls containing these words)
 - `cat urls.txt | cariddi -it ignore_file` (Ignore urls containing at least one line in the input file)
@@ -216,6 +217,8 @@ Usage of cariddi:
      Print only the results.
   -proxy string
      Set a Proxy to be used (http and socks5 supported).
+  -rl, -rate-limit int
+     Maximum requests per second across all workers (0 means unlimited).
   -rua
      Use a random browser user agent on every request.
   -s Hunt for secrets.

--- a/cmd/cariddi/main.go
+++ b/cmd/cariddi/main.go
@@ -69,6 +69,7 @@ func main() {
 	// passed via the CLI
 	config := &crawler.Scan{
 		Delay:            flags.Delay,
+		RateLimit:        flags.RateLimit,
 		Concurrency:      flags.Concurrency,
 		Ignore:           flags.Ignore,
 		IgnoreTxt:        flags.IgnoreTXT,

--- a/pkg/crawler/colly.go
+++ b/pkg/crawler/colly.go
@@ -100,7 +100,7 @@ func New(scan *Scan) *Results {
 	}
 
 	// crawler creation
-	c := CreateColly(scan.Delay, scan.Concurrency, scan.Timeout, scan.MaxDepth,
+	c := CreateCollyWithRateLimit(scan.Delay, scan.RateLimit, scan.Concurrency, scan.Timeout, scan.MaxDepth,
 		scan.Cache, scan.Intensive, scan.Rua,
 		scan.Proxy, scan.UserAgent, scan.Target)
 
@@ -270,11 +270,27 @@ func New(scan *Scan) *Results {
 func CreateColly(delayTime, concurrency, timeout, maxDepth int,
 	cache, intensive, rua bool,
 	proxy string, userAgent string, target string) *colly.Collector {
+	return CreateCollyWithRateLimit(delayTime, 0, concurrency, timeout, maxDepth,
+		cache, intensive, rua, proxy, userAgent, target)
+}
+
+// CreateCollyWithRateLimit creates a collector with a global requests-per-second limit.
+func CreateCollyWithRateLimit(delayTime, rateLimit, concurrency, timeout, maxDepth int,
+	cache, intensive, rua bool,
+	proxy string, userAgent string, target string) *colly.Collector {
 	c := colly.NewCollector(
 		colly.Async(true),
 	)
 	c.IgnoreRobotsTxt = true
 	c.AllowURLRevisit = false
+
+	if rateLimit > 0 {
+		limiter := newRequestRateLimiter(rateLimit)
+
+		c.OnRequest(func(_ *colly.Request) {
+			limiter.Wait()
+		})
+	}
 
 	err := c.Limit(
 		&colly.LimitRule{

--- a/pkg/crawler/options.go
+++ b/pkg/crawler/options.go
@@ -68,6 +68,7 @@ type Scan struct {
 	// Settings
 	Concurrency int
 	Delay       int
+	RateLimit   int
 	Timeout     int
 
 	// Storage

--- a/pkg/crawler/ratelimit.go
+++ b/pkg/crawler/ratelimit.go
@@ -1,0 +1,72 @@
+/*
+==========
+Cariddi
+==========
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see http://www.gnu.org/licenses/.
+
+	@Repository:  https://github.com/edoardottt/cariddi
+
+	@Author:      edoardottt, https://edoardottt.com
+
+	@License: https://github.com/edoardottt/cariddi/blob/main/LICENSE
+
+*/
+
+package crawler
+
+import (
+	"sync"
+	"time"
+)
+
+type requestRateLimiter struct {
+	mutex    sync.Mutex
+	interval time.Duration
+	next     time.Time
+}
+
+func newRequestRateLimiter(requestsPerSecond int) *requestRateLimiter {
+	rate := time.Duration(requestsPerSecond)
+
+	interval := time.Second / rate
+	if time.Second%rate != 0 {
+		interval++
+	}
+
+	return &requestRateLimiter{
+		interval: interval,
+	}
+}
+
+// Wait spaces request starts across every concurrent collector worker.
+// The first request proceeds immediately; later requests start no faster
+// than the configured interval.
+func (limiter *requestRateLimiter) Wait() {
+	limiter.mutex.Lock()
+	defer limiter.mutex.Unlock()
+
+	now := time.Now()
+	if wait := limiter.next.Sub(now); wait > 0 {
+		time.Sleep(wait)
+
+		now = time.Now()
+	}
+
+	if now.Before(limiter.next) {
+		now = limiter.next
+	}
+
+	limiter.next = now.Add(limiter.interval)
+}

--- a/pkg/crawler/ratelimit_test.go
+++ b/pkg/crawler/ratelimit_test.go
@@ -1,0 +1,90 @@
+/*
+==========
+Cariddi
+==========
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see http://www.gnu.org/licenses/.
+
+	@Repository:  https://github.com/edoardottt/cariddi
+
+	@Author:      edoardottt, https://edoardottt.com
+
+	@License: https://github.com/edoardottt/cariddi/blob/main/LICENSE
+
+*/
+
+package crawler_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/edoardottt/cariddi/pkg/crawler"
+)
+
+func TestCreateCollyAppliesRateLimitAcrossWorkers(t *testing.T) {
+	var (
+		mutex        sync.Mutex
+		requestTimes []time.Time
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		mutex.Lock()
+
+		requestTimes = append(requestTimes, time.Now())
+		mutex.Unlock()
+
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	const (
+		rateLimit    = 10
+		requestCount = 4
+	)
+
+	target := strings.TrimPrefix(server.URL, "http://")
+	collector := crawler.CreateCollyWithRateLimit(0, rateLimit, requestCount, 10, 0,
+		false, false, false, "", "", target)
+
+	for index := range requestCount {
+		if err := collector.Visit(fmt.Sprintf("%s/%d", server.URL, index)); err != nil {
+			t.Fatalf("queue request %d: %v", index, err)
+		}
+	}
+
+	collector.Wait()
+
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	if len(requestTimes) != requestCount {
+		t.Fatalf("server received %d requests, want %d", len(requestTimes), requestCount)
+	}
+
+	sort.Slice(requestTimes, func(first, second int) bool {
+		return requestTimes[first].Before(requestTimes[second])
+	})
+
+	minimumSpan := 240 * time.Millisecond
+	if span := requestTimes[len(requestTimes)-1].Sub(requestTimes[0]); span < minimumSpan {
+		t.Fatalf("requests spanned %v, want at least %v", span, minimumSpan)
+	}
+}

--- a/pkg/input/check.go
+++ b/pkg/input/check.go
@@ -112,6 +112,11 @@ func CheckFlags(flags Input) {
 		os.Exit(1)
 	}
 
+	if flags.RateLimit < 0 {
+		fmt.Println("The rate limit must be zero or a positive value.")
+		os.Exit(1)
+	}
+
 	if flags.Ignore != "" && flags.IgnoreTXT != "" {
 		fmt.Println("You should use only one among -i and -it.")
 		fmt.Println("Examples:")

--- a/pkg/input/flags.go
+++ b/pkg/input/flags.go
@@ -46,6 +46,8 @@ type Input struct {
 	Version bool
 	// Delay between a page crawled and another.
 	Delay int
+	// RateLimit is the maximum number of requests per second across all workers.
+	RateLimit int
 	// Concurrency level.
 	Concurrency int
 	// Help prints the help banner.
@@ -112,6 +114,10 @@ type Input struct {
 func ScanFlag() Input {
 	versionPtr := flag.Bool("version", false, "Print the version.")
 	delayPtr := flag.Int("d", 0, "Delay between a page crawled and another.")
+	rateLimitPtr := new(int)
+	flag.IntVar(rateLimitPtr, "rl", 0, "Maximum requests per second across all workers (0 means unlimited).")
+	flag.IntVar(rateLimitPtr, "rate-limit", 0, "Maximum requests per second across all workers (0 means unlimited).")
+
 	concurrencyPtr := flag.Int("c", DefaultConcurrency, "Concurrency level.")
 	helpPtr := flag.Bool("h", false, "Print the help.")
 	examplesPtr := flag.Bool("examples", false, "Print the examples.")
@@ -168,6 +174,7 @@ func ScanFlag() Input {
 	result := Input{
 		*versionPtr,
 		*delayPtr,
+		*rateLimitPtr,
 		*concurrencyPtr,
 		*helpPtr,
 		*examplesPtr,

--- a/pkg/input/flags_test.go
+++ b/pkg/input/flags_test.go
@@ -1,0 +1,60 @@
+/*
+==========
+Cariddi
+==========
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see http://www.gnu.org/licenses/.
+
+	@Repository:  https://github.com/edoardottt/cariddi
+
+	@Author:      edoardottt, https://edoardottt.com
+
+	@License: https://github.com/edoardottt/cariddi/blob/main/LICENSE
+
+*/
+
+package input_test
+
+import (
+	"flag"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/edoardottt/cariddi/pkg/input"
+)
+
+func TestScanFlagRateLimitAliases(t *testing.T) {
+	originalCommandLine := flag.CommandLine
+	originalArgs := os.Args
+
+	t.Cleanup(func() {
+		flag.CommandLine = originalCommandLine
+		os.Args = originalArgs
+	})
+
+	for _, name := range []string{"-rl", "-rate-limit"} {
+		t.Run(name, func(t *testing.T) {
+			flag.CommandLine = flag.NewFlagSet("cariddi", flag.ContinueOnError)
+			flag.CommandLine.SetOutput(io.Discard)
+
+			os.Args = []string{"cariddi", name, "7"}
+
+			flags := input.ScanFlag()
+			if flags.RateLimit != 7 {
+				t.Fatalf("%s set rate limit to %d, want 7", name, flags.RateLimit)
+			}
+		})
+	}
+}

--- a/pkg/output/examples.go
+++ b/pkg/output/examples.go
@@ -56,6 +56,8 @@ func PrintExamples() {
 
 	cat urls | cariddi -c 200 (Set the concurrency level to 200)
 
+	cat urls | cariddi -rl 10 (Limit all workers to 10 requests per second)
+
 	cat urls | cariddi -plain (Print only results)
 
 	cat urls | cariddi -ot target_name (Results in txt file)

--- a/pkg/output/help.go
+++ b/pkg/output/help.go
@@ -76,6 +76,8 @@ func PrintHelp() {
 		Print only the results.
 	-proxy string
 		Set a Proxy to be used (http and socks5 supported).
+	-rl, -rate-limit int
+		Maximum requests per second across all workers (0 means unlimited).
 	-rua
 		Use a random browser user agent on every request.
 	-s	Hunt for secrets.


### PR DESCRIPTION
Fixes #155.

## What changed

- adds `-rl` and `-rate-limit` as equivalent requests-per-second flags;
- applies one limiter across every asynchronous worker in a collector;
- keeps the first request immediate, then spaces request starts to enforce the configured aggregate rate without bursts;
- rejects negative values while preserving `0` as the unlimited default;
- documents the option in the README, help, and examples; and
- preserves the existing exported `CreateColly` signature for downstream callers, with `CreateCollyWithRateLimit` providing the new behavior.

## Why

The existing `-d` option is a Colly delay rule. With multiple asynchronous workers, it does not express a precise aggregate requests-per-second ceiling, which is the gap described in #155. The new limiter serializes only request admission; response handling remains concurrent.

This implementation uses the standard library and adds no dependency. If both `-d` and a rate limit are configured, both constraints apply.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 run` -> 0 issues
- `go run ./cmd/cariddi -h` -> both aliases and their semantics are present

The tests cover both CLI aliases and use a local `httptest` server to verify that concurrent workers observe one aggregate rate limit.
